### PR TITLE
Enable NPU training

### DIFF
--- a/ai_models/model_mla.py
+++ b/ai_models/model_mla.py
@@ -536,9 +536,16 @@ if __name__ == "__main__":
     parser.add_argument("--epochs", type=int, default=20)
     parser.add_argument("--batch_size", type=int, default=32)
     parser.add_argument("--lr", type=float, default=5e-4)
+    parser.add_argument("--npu", action="store_true", help="Use available NPUs for training")
     args = parser.parse_args()
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if args.npu:
+        if hasattr(torch, "npu") and torch.npu.is_available():
+            device = torch.device("npu")
+        else:
+            raise RuntimeError("--npu specified but NPU support is unavailable")
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
 
     # Get basis from filename
@@ -568,6 +575,14 @@ if __name__ == "__main__":
     print(f"Rounds={R} Stabilisers={S} Features={F} grid={d}×{d}")
     
     model = AlphaQubitDecoder(F, 128, S, grid_size)
+    if args.npu and hasattr(torch, "npu"):
+        npu_count = getattr(torch.npu, "device_count", lambda: 1)()
+        if npu_count > 1:
+            print(f"Using {npu_count} NPUs!")
+            model = nn.DataParallel(model)
+    elif not args.npu and torch.cuda.device_count() > 1:
+        print(f"Using {torch.cuda.device_count()} GPUs!")
+        model = nn.DataParallel(model)
     
     # Generate model save path from input file name
     model_save_path = get_model_name_from_path(args.npz_file)

--- a/run_fine_tune_all.py
+++ b/run_fine_tune_all.py
@@ -34,6 +34,7 @@ def main():
         default=16,
         help="Batch size to pass to fine_tune"
     )
+    parser.add_argument("--npu", action="store_true", help="Use NPUs for training")
     args = parser.parse_args()
 
     project_root  = Path(__file__).resolve().parent
@@ -74,6 +75,8 @@ def main():
             "--epochs",     str(args.epochs),
             "--batch-size", str(args.batch_size),
         ]
+        if args.npu:
+            sys.argv.append("--npu")
         runpy.run_path(str(ft_script), run_name="__main__")
 
 if __name__ == "__main__":

--- a/run_train_all.py
+++ b/run_train_all.py
@@ -7,6 +7,7 @@ without spawning concurrent processes.
 """
 
 import subprocess
+import argparse
 from pathlib import Path
 
 # Config
@@ -16,6 +17,9 @@ SCRIPT     = Path("ai_models/model_mla.py")
 DATA_DIR   = Path("simulated_data")
 
 def main():
+    parser = argparse.ArgumentParser(description="Train all NPZ files serially")
+    parser.add_argument("--npu", action="store_true", help="Use NPUs for training")
+    args = parser.parse_args()
     npz_files = sorted(DATA_DIR.glob("*.npz"))
     if not npz_files:
         print(f"No .npz files found in {DATA_DIR}")
@@ -28,6 +32,8 @@ def main():
             "--batch_size", BATCH_SIZE,
             "--npz_file", str(npz)
         ]
+        if args.npu:
+            cmd.append("--npu")
         print(f"\nRunning: {' '.join(cmd)}")
         # This will block until the script finishes for each file
         subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Summary
- allow using Ascend NPUs by adding a `--npu` flag to training scripts
- support DataParallel across multiple NPUs when available
- propagate the new flag through helper run scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_6879fdbdbc78832a8cc99c229768e2c7