### PR TITLE
Attach noise to gates and use full SI1000 model

### DIFF
--- a/configs/si1000.yaml
+++ b/configs/si1000.yaml
@@ -1,2 +1,4 @@
 # SI1000 noise parameters
 p: 0.001  # Base error rate
+distance: 3
+rounds: 25

--- a/generate_data.py
+++ b/generate_data.py
@@ -17,12 +17,12 @@ def main(model_type: str, num_samples: int, basis: str):
     if model_type == "dem":
         syndromes, logicals = generate_dem_data(num_samples, config)
     elif model_type == "si1000":
-        circuit = si1000_noise_model(config["p"])
+        circuit = si1000_noise_model(config)
         sampler = circuit.compile_detector_sampler()
         syndromes, logicals = sampler.sample(num_samples, separate_observables=True)
     elif model_type == "pauli_plus":
         sim = PauliPlusSimulator(config, basis)
-        sampler = sim.circuit.compile_detector_sampler()      # or however your class exposes it
+        sampler = sim.circuit.compile_detector_sampler()
         syndromes, logicals = sampler.sample(num_samples, separate_observables=True)
 
     else:

--- a/simulator/pauli_plus_simulator.py
+++ b/simulator/pauli_plus_simulator.py
@@ -1,85 +1,61 @@
 import stim
-import numpy as np
-from scipy.stats import multivariate_normal
-import random
+
 
 class PauliPlusSimulator:
-    def __init__(self, config):
-        # Config parameters with defaults
+    """Simulator adding leakage and cross-talk noise after two-qubit gates."""
+
+    def __init__(self, config, basis: str):
+        self.distance = config.get("distance")
+        self.rounds = config.get("rounds")
+        if self.distance is None or self.rounds is None:
+            raise ValueError("config must include 'distance' and 'rounds'")
+
         self.depolarization = config.get("depolarization", 0.001)
         self.leakage_rate = config.get("leakage_rate", 0.01)
         self.cross_talk = config.get("cross_talk", 0.002)
-        self.t1 = config.get("t1", 1000)
-        self.measurement_duration = config.get("measurement_duration", 100)
-        
-        # Possible values like Google's experiment
-        self.possible_distances = [3, 5]  # Could add 7,9,11 etc.
-        self.possible_rounds = list(range(1, 26, 2))  # 1,3,...,25
-        self.possible_bases = ['X', 'Z']
-    
-    def generate_experiment_config(self):
-        """Generate a random experiment configuration"""
-        return {
-            "distance": random.choice(self.possible_distances),
-            "rounds": random.choice(self.possible_rounds),
-            "basis": random.choice(self.possible_bases)
-        }
-    
-    def generate_experiment(self, config=None):
-        """Generate a circuit with random parameters if none provided"""
-        if config is None:
-            config = self.generate_experiment_config()
-            
-        self.distance = config["distance"]
-        self.rounds = config["rounds"]
-        self.basis = config["basis"]
-        
-        self.circuit = self._build_noisy_circuit(self.basis)
-        return self.circuit
-    
-    def _build_noisy_circuit(self, basis):
+
+        self.basis = basis.upper()
+        if self.basis not in ("X", "Z"):
+            raise ValueError("basis must be 'X' or 'Z'")
+
+        self.circuit = self._build_noisy_circuit()
+
+    def _build_noisy_circuit(self) -> stim.Circuit:
         circuit = stim.Circuit.generated(
-            "surface_code:rotated_memory_"+basis,
+            f"surface_code:rotated_memory_{self.basis.lower()}",
             rounds=self.rounds,
             distance=self.distance,
-            after_clifford_depolarization=self.depolarization
+            after_clifford_depolarization=self.depolarization,
         )
-        circuit = self._add_leakage_to_cz(circuit)
-        circuit = self._add_cross_talk(circuit)
-        return circuit
+        return self._attach_noise_to_two_qubit_gates(circuit)
 
-    def _add_leakage_to_cz(self, circuit):
-        """Add leakage noise to CZ gates with proper PAULI_CHANNEL_2 parameters"""
-        for i in range(self.distance**2 - 1):
-            circuit.append_operation("PAULI_CHANNEL_2", [i, i+1], [
-                # 15 parameters for all non-identity Pauli combinations
-                self.leakage_rate/3,  # IX
-                self.leakage_rate/3,  # IY
-                self.leakage_rate/3,  # IZ
-                0, 0, 0, 0,           # XI, XX, XY, XZ
-                0, 0, 0, 0,           # YI, YX, YY, YZ
-                0, 0, 0, 0            # ZI, ZX, ZY, ZZ
-            ])
-        return circuit
-
-    def _add_cross_talk(self, circuit):
-        for q in range(self.distance**2 - 1):
-            neighbors = self._get_adjacent_qubits(q)
-            for n in neighbors:
-                if n > q:
-                    circuit.append_operation("DEPOLARIZE2", [q, n], self.cross_talk)
-        return circuit
-
-    def _get_adjacent_qubits(self, q):
-        row = q // self.distance
-        col = q % self.distance
-        neighbors = []
-        if col > 0: neighbors.append(q - 1)
-        if col < self.distance - 1: neighbors.append(q + 1)
-        if row > 0: neighbors.append(q - self.distance)
-        if row < self.distance - 1: neighbors.append(q + self.distance)
-        return neighbors
-
-    def generate_batch(self, num_experiments):
-        """Generate multiple experiments with random configurations"""
-        return [self.generate_experiment() for _ in range(num_experiments)]
+    def _attach_noise_to_two_qubit_gates(self, circuit: stim.Circuit) -> stim.Circuit:
+        """Insert leakage and cross-talk noise after each two-qubit gate."""
+        noisy = stim.Circuit()
+        for inst in circuit:
+            noisy.append(inst)
+            if inst.name in ("CX", "CZ"):
+                targets = [t.value for t in inst.targets_copy()]
+                noisy.append_operation(
+                    "PAULI_CHANNEL_2",
+                    targets,
+                    [
+                        self.leakage_rate / 3,
+                        self.leakage_rate / 3,
+                        self.leakage_rate / 3,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                    ],
+                )
+                noisy.append_operation("DEPOLARIZE2", targets, self.cross_talk)
+        return noisy

--- a/simulator/si1000_generator.py
+++ b/simulator/si1000_generator.py
@@ -1,11 +1,18 @@
 import stim
 
-def si1000_noise_model(p: float) -> stim.Circuit:
+
+def si1000_noise_model(config: dict) -> stim.Circuit:
+    """Construct a surface-code circuit using Stim's SI1000 noise model."""
+    p = config.get("p", 0.001)
+    distance = config.get("distance", 3)
+    rounds = config.get("rounds", 25)
     circuit = stim.Circuit.generated(
         "surface_code:rotated_memory_z",
-        rounds=25,
-        distance=3,
-        after_clifford_depolarization=p/10,
-        after_reset_flip_probability=5*p,
+        rounds=rounds,
+        distance=distance,
+        after_clifford_depolarization=p / 10,
+        before_round_data_depolarization=p / 10,
+        before_measure_flip_probability=5 * p,
+        after_reset_flip_probability=5 * p,
     )
     return circuit

--- a/src/tests/test_noise_models.py
+++ b/src/tests/test_noise_models.py
@@ -1,0 +1,40 @@
+import numpy as np
+import stim
+
+from simulator.si1000_generator import si1000_noise_model
+from simulator.pauli_plus_simulator import PauliPlusSimulator
+
+
+def test_si1000_zero_noise():
+    config = {"p": 0.0, "distance": 3, "rounds": 3}
+    circuit = si1000_noise_model(config)
+    sampler = circuit.compile_detector_sampler()
+    syndromes, logicals = sampler.sample(100, separate_observables=True)
+    assert np.all(syndromes == 0)
+    assert np.all(logicals == 0)
+
+
+def test_pauli_plus_noise_attached_to_gates():
+    config = {
+        "distance": 3,
+        "rounds": 3,
+        "depolarization": 0.0,
+        "leakage_rate": 0.0,
+        "cross_talk": 0.0,
+    }
+    sim = PauliPlusSimulator(config, 'z')
+    ops = list(sim.circuit)
+    for idx, inst in enumerate(ops):
+        if inst.name in ("CX", "CZ"):
+            next1 = ops[idx + 1]
+            next2 = ops[idx + 2]
+            assert next1.name == "PAULI_CHANNEL_2"
+            assert next2.name == "DEPOLARIZE2"
+            break
+    else:
+        assert False, "No two-qubit gate found in circuit"
+
+    sampler = sim.circuit.compile_detector_sampler()
+    syndromes, logicals = sampler.sample(100, separate_observables=True)
+    assert np.all(syndromes == 0)
+    assert np.all(logicals == 0)


### PR DESCRIPTION
## Summary
- Build `PauliPlusSimulator` circuits with validated configs and insert leakage and cross-talk noise directly after each two-qubit gate
- Generate SI1000 circuits with configurable distance/rounds and include idle and measurement errors
- Add regression tests for SI1000 and Pauli+ noise models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68995c8552e0832a96ebb0bd84564a41