### PR TITLE
Add injection control toggles to paper-aligned config

### DIFF
--- a/configs/paper_aligned.yaml
+++ b/configs/paper_aligned.yaml
@@ -54,3 +54,9 @@ decoder_inputs:
   use_soft_detection_events: true
   provide_intermediate_labels_in_pretrain_only: true
 
+# Injection controls
+# Whether to add a PAULI_CHANNEL_1 idle twirl on all qubits at each TICK.
+twirl_idles_each_tick: false
+# If true, apply GPT-twirled 1Q noise after any recognized 1Q gate.
+twirl_after_1q_gates: true
+


### PR DESCRIPTION
## Summary
- add idle and 1Q gate twirl control flags in `paper_aligned.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68ae8661579c832a8a29f24aeeb6d7fd