### PR TITLE
feat: model heating and dqlr in noise model

### DIFF
--- a/google_qec_paper_noise_model/channels.py
+++ b/google_qec_paper_noise_model/channels.py
@@ -112,22 +112,78 @@ def cz_induced_leakage_kraus(p_leak: float) -> List[np.ndarray]:
     return [K0, K1, K2]
 
 def leakage_transport_kraus(p_move: float) -> List[np.ndarray]:
+    """Simplified leakage transport channel.
+
+    The Supplementary Information of the paper describes a stochastic process
+    that moves population from ``|12>`` to ``|30>`` (and ``|21>`` to ``|03>``)
+    during a faulty CZ.  Our simulator only models up to the ``|2>`` level, so
+    we approximate this transport as a swap of leakage between the two qubits.
+
+    With probability ``p_move/2`` the state ``|12>`` becomes ``|21>`` and with
+    the same probability ``|21>`` becomes ``|12>``.  The remainder of the time
+    the channel acts as identity.  This captures the stochastic transport of
+    leakage between qubits while keeping the model within a two-qutrit space.
     """
-    Two-qutrit 'transport' where leakage on one qubit propagates during CZ
-    (e.g., |12> <-> |30> like effects in multi-level systems).
-    Simplified as a swap-like stochastic move from |12>/<21> to |30>/<03>.
-    """
+
     p = float(p_move)
     dim = 9
     I9 = np.eye(dim, dtype=complex)
-    K0 = np.sqrt(1.0 - p) * I9
-    K1 = np.zeros((dim,dim), complex)
-    # |12> -> |30>
-    K1[3*3//3 + 0, 3*1 + 2] = np.sqrt(p/2.0)  # idx 6->? keep formula simple
-    # |21> -> |03>
-    K1[3*0 + 3//1, 3*2 + 1] = K1[0,0]  # dummy to ensure shape; kept for extensibility
-    # NOTE: Simplified; downstream GPTA will twirl this anyway.
-    return [K0]  # keep conservative (transport folded into K0 phenomenologically)
+
+    # Identity branch with reduced amplitudes on the affected states.
+    K0 = I9.copy()
+    idx12 = 3 * 1 + 2
+    idx21 = 3 * 2 + 1
+    K0[idx12, idx12] = np.sqrt(max(0.0, 1.0 - p / 2.0))
+    K0[idx21, idx21] = np.sqrt(max(0.0, 1.0 - p / 2.0))
+
+    # Swapped branches |12><21| and |21><12|
+    K1 = np.zeros((dim, dim), complex)
+    K2 = np.zeros((dim, dim), complex)
+    K1[idx12, idx21] = np.sqrt(p / 2.0)
+    K2[idx21, idx12] = np.sqrt(p / 2.0)
+
+    return [K0, K1, K2]
+
+
+def passive_heating_kraus(p_heat: float) -> List[np.ndarray]:
+    """Single-qutrit passive heating into ``|2>``.
+
+    Each basis state ``|0>`` or ``|1>`` moves to the leaked level ``|2>`` with
+    probability ``p_heat``.  ``|2>`` remains ``|2>``.  The channel is trace
+    preserving and acts as identity when ``p_heat=0``.
+    """
+
+    p = float(p_heat)
+    I3 = np.eye(3, dtype=complex)
+    K0 = np.sqrt(1.0 - p) * I3
+    K1 = np.zeros((3, 3), complex)
+    K2 = np.zeros((3, 3), complex)
+    # |2><0| and |2><1|
+    K1[2, 0] = np.sqrt(p)
+    K2[2, 1] = np.sqrt(p)
+    return [K0, K1, K2]
+
+
+def dqlr_kraus(p_matrix: List[List[float]]) -> List[np.ndarray]:
+    """Kraus operators for an imperfect DQLR reset channel.
+
+    ``p_matrix`` is a 3x3 matrix where element ``p_matrix[i][j]`` gives the
+    probability of resetting from state ``|j>`` to ``|i>``.  The resulting Kraus
+    operators satisfy ``sum_i K_i† K_i = I`` provided each column of
+    ``p_matrix`` sums to 1.
+    """
+
+    P = np.array(p_matrix, dtype=float)
+    Ks: List[np.ndarray] = []
+    for i in range(3):
+        for j in range(3):
+            amp = np.sqrt(max(P[i, j], 0.0))
+            if amp == 0:
+                continue
+            K = np.zeros((3, 3), complex)
+            K[i, j] = amp
+            Ks.append(K)
+    return Ks
 
 def spectator_crosstalk_z_kraus(p: float) -> List[np.ndarray]:
     """

--- a/google_qec_paper_noise_model/paper_aligned.py
+++ b/google_qec_paper_noise_model/paper_aligned.py
@@ -1,219 +1,103 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple
 import numpy as np
+
 from simulator.pauli_plus_simulator import PauliPlusSimulator
-from .gpt import gpt_single_qubit, amp_phase_kraus
- 
+from .gpt import amp_phase_kraus
+from .gpta import twirl_to_pauli_channel
+from .channels import passive_heating_kraus, lift_qubit_to_qutrit, dqlr_kraus
+from . import kraus_utils
+
+
 @dataclass
 class PaperAlignedNoiseConfig:
-    # Timing
+    """Noise parameters following the paper's methodology."""
+
+    # Timing (ns)
     cycle_ns: float = 1100.0
     # Decoherence
     T1_us: float = 68.0
     Tphi_us: float = 89.0
-    p_heat: float = 0.0  # passive heating to |2>, folded through GPT (see note)
-    # Readout / reset
+    p_heat: float = 0.0  # passive heating to |2>
+    # Readout / reset (classical bit-flip rates)
     p_readout: float = 0.003
     p_reset: float = 0.003
-    # DQLR (acts on |0>,|1>,|2|; folded via GPT on computational subspace here)
+    # DQLR imperfection matrix P_{j->i} on |0>,|1>,|2>
     dqlr_matrix: Tuple[Tuple[float, ...], ...] = (
         (1.0, 0.0, 0.0),
         (0.0, 1.0, 0.0),
         (0.05, 0.90, 0.05),
     )
     # CZ related mechanisms
-    p_cz_leak_11_to_02: float = 0.001    # folded via GPT
+    p_cz_leak_11_to_02: float = 0.001
     p_cz_crosstalk_ZZ: float = 0.0005
-    p_cz_swap_like: float = 0.0005       # approximated by (XX+YY)/2
-    p_leak_transport_12_to_30: float = 0.0005  # folded via GPT
-    # “Excess” residual errors
-    p_1q_excess: float = 0.0005
-    p_cz_excess: float = 0.0010
-    p_idle_excess: float = 0.0005
-    # Injection controls
-    twirl_idles_each_tick: bool = False
-    twirl_after_1q_gates: bool = True
-
-class PaperAlignedNoiseModel:
- 
-
-    """
-    Paper-aligned noise model with GPT per channel.
-
-    Implements *all* physical error mechanisms enumerated in the Methods / SI of
-    "Quantum error correction below the surface code threshold" and applies
-    Generalized Pauli Twirling (GPT) to each noise channel before simulation.
-
-    Primary reference:
-      - SI, IV.A.1 "Surface Code Simulation Details" (list of mechanisms and GPT step).
-      - DQLR imperfection modeled via Kraus channel on |0>,|1>,|2> (same section).
-    """
-
-
-
-
-    def _amp_damp_kraus(gamma: float) -> List[np.ndarray]:
-        """Single-qubit amplitude damping Kraus (|1>→|0>) with rate gamma."""
-        K0 = np.array([[1, 0], [0, np.sqrt(1 - gamma)]], dtype=complex)
-        K1 = np.array([[0, np.sqrt(gamma)], [0, 0]], dtype=complex)
-        return [K0, K1]
-
-
-    def _phase_damp_kraus(lam: float) -> List[np.ndarray]:
-        """Single-qubit pure dephasing Kraus with rate lambda."""
-        K0 = np.sqrt(1 - lam) * np.eye(2, dtype=complex)
-        K1 = np.sqrt(lam) * np.array([[1, 0], [0, -1]], dtype=complex) / 1.0  # Z-like
-        return [K0, K1]
-
-
-@dataclass
-class PaperAlignedNoiseConfig:
-    # Timing (ns)
-    cycle_ns: float = 1100.0
-    # Decoherence parameters (from device means in paper text; adjust via YAML as needed)
-    T1_us: float = 68.0
-    Tphi_us: float = 89.0
-    p_heat: float = 0.0  # passive heating into |2>, modeled classically
-    # Readout/reset
-    p_readout: float = 0.003
-    p_reset: float = 0.003
-    # DQLR (data-qubit leakage removal) imperfection P_{j->i} on |0>,|1>,|2>
-    dqlr_matrix: List[List[float]] = ((1.0, 0.0, 0.0),
-                                      (0.0, 1.0, 0.0),
-                                      (0.05, 0.90, 0.05))  # example; adjust with calibration
-    # CZ related correlated mechanisms
-    p_cz_leak_11_to_02: float = 0.001   # dephasing-induced leakage during CZ
-    p_cz_crosstalk_ZZ: float = 0.0005   # parallel CZ crosstalk -> ZZ
-    p_cz_swap_like: float = 0.0005      # swap-like error during parallel CZ
+    p_cz_swap_like: float = 0.0005
     p_leak_transport_12_to_30: float = 0.0005
-    # “Excess” residual errors (not captured above)
+    # Residual Pauli noise
     p_1q_excess: float = 0.0005
     p_cz_excess: float = 0.0010
     p_idle_excess: float = 0.0005
 
 
-
-
-
-from simulator.pauli_plus_simulator import PauliPlusSimulator
-
-
-@dataclass
-class PaperAlignedConfig:
-    """Subset of noise parameters used by the paper-aligned model."""
-    p_1q_excess: float = 0.0
-    p_cz_excess: float = 0.0
-    p_idle_excess: float = 0.0
-    p_cz_leak_11_to_02: float = 0.0
-    p_cz_crosstalk_ZZ: float = 0.0
-    p_cz_swap_like: float = 0.0
-
-
 class PaperAlignedNoiseModel:
-      """
-    High-level façade that:
-      1) Builds per-operation channels (T1/Tphi, leakage, CZ crosstalk, etc.)
-      2) Applies GPT to each channel (Pauli twirl on the computational subspace)
-      3) Produces synthetic syndromes/logical bits consistent with the Pauli+ mix.
+    """High-level facade applying paper-aligned noise to Pauli+ simulator."""
 
-    NOTE: This module focuses on *methodological* alignment with the paper.
-    Channel *rates* must be set from calibration/experiment (YAML) if you want to
-    reproduce a specific dataset’s numbers.
-    """
-
- 
     def __init__(self, config: Dict, basis: str = "z"):
         self.cfg = self._load_cfg(config)
         self.basis = basis.lower()
         if self.basis not in ("x", "z"):
             raise ValueError("basis must be 'x' or 'z'")
- 
-        # Build existing Pauli+ simulator/circuit then instrument with paper noise
+
+        # Build simulator and instrument with paper noise
         self.sim = PauliPlusSimulator(config, basis)
         self.sim.apply_paper_aligned_noise(config=self.cfg.__dict__)
- 
- 
 
-        # Precompute GPT-twirled single-qubit channels for convenience
-        self._ptm_1q_idle = self._build_idle_ptm()
-        self._ptm_1q_excess = {"I": 1 - self.cfg.p_1q_excess,
-                               "X": self.cfg.p_1q_excess / 3,
-                               "Y": self.cfg.p_1q_excess / 3,
-                               "Z": self.cfg.p_1q_excess / 3}
- 
+        # Precompute GPT-twirled single-qubit channels
+        self._ptm_1q_idle, self._p_idle_leak = self._build_idle_ptm()
+        self._ptm_dqlr, self._p_dqlr_leak = self._build_dqlr_ptm()
+        self._ptm_1q_excess = {
+            "I": 1 - self.cfg.p_1q_excess,
+            "X": self.cfg.p_1q_excess / 3,
+            "Y": self.cfg.p_1q_excess / 3,
+            "Z": self.cfg.p_1q_excess / 3,
+        }
 
     def _load_cfg(self, raw: Dict) -> PaperAlignedNoiseConfig:
-        d = PaperAlignedNoiseConfig()
+        cfg = PaperAlignedNoiseConfig()
         for k, v in (raw or {}).items():
-            if hasattr(d, k):
-                setattr(d, k, v)
-        return d
- 
-    def sample(self, num_samples: int) -> Tuple[np.ndarray, np.ndarray]:
-        sampler = self.sim.circuit.compile_detector_sampler()
-        syndromes, logicals = sampler.sample(num_samples, separate_observables=True)
- 
-    def _build_idle_ptm(self) -> Dict[str, float]:
-        """Compose amplitude+phase damping over one cycle and GPT-twirl."""
+            if hasattr(cfg, k):
+                setattr(cfg, k, v)
+        return cfg
+
+    def _build_idle_ptm(self) -> Tuple[Dict[str, float], float]:
         dt_us = self.cfg.cycle_ns / 1000.0
-        gamma = 1.0 - np.exp(-dt_us / self.cfg.T1_us)  # T1
-        lam = 1.0 - np.exp(-dt_us / self.cfg.Tphi_us)  # Tphi
-        K = []
-        # Sequential Kraus application approximation: amplitude then phase damping
-        K_amp = _amp_damp_kraus(gamma)
-        for Ka in K_amp:
-            for Kp in _phase_damp_kraus(lam):
-                K.append(Kp @ Ka)
-        return gpt_single_qubit(K)
+        K_amp_phase = amp_phase_kraus(dt_us, self.cfg.T1_us, self.cfg.Tphi_us)
+        K = lift_qubit_to_qutrit(K_amp_phase)
+        if self.cfg.p_heat > 0:
+            heat = passive_heating_kraus(self.cfg.p_heat)
+            K = kraus_utils.combine_kraus_channels(K, heat)
+        probs, leak = twirl_to_pauli_channel(K, 1)
+        ptm = {
+            "I": float(probs[0]),
+            "X": float(probs[1]),
+            "Y": float(probs[2]),
+            "Z": float(probs[3]),
+        }
+        return ptm, float(leak)
 
-    # -------------------------------
-    # Public API
-    # -------------------------------
-    def sample(self, num_samples: int) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Produce a toy (but method-aligned) synthetic dataset:
-        - 'syndromes' as bits for a rectangular surface code patch with
-          parity checks toggled by GPT-twirled single-qubit idling/gate errors.
-        - 'logicals' as observable flips derived from a simple per-cycle LER model.
+    def _build_dqlr_ptm(self) -> Tuple[Dict[str, float], float]:
+        Ks = dqlr_kraus(self.cfg.dqlr_matrix)
+        probs, leak = twirl_to_pauli_channel(Ks, 1)
+        ptm = {
+            "I": float(probs[0]),
+            "X": float(probs[1]),
+            "Y": float(probs[2]),
+            "Z": float(probs[3]),
+        }
+        return ptm, float(leak)
 
-        This keeps the same output contract as your other generators but focuses
-        on the *noise model method* (channels + GPT) rather than chip geometry.
-        """
-        # Simple “size” for demonstration; downstream code expects arrays
-        n_detectors = 256  # adjust as needed
-        n_observables = 1
-
-        # Effective per-detector flip rate from idle+excess (very rough aggregation)
-        p_flip = min(0.5, self._ptm_1q_idle.get("X", 0.0) +
-                           self._ptm_1q_idle.get("Y", 0.0) +
-                           self._ptm_1q_idle.get("Z", 0.0) +
-                           self.cfg.p_idle_excess)
-        rng = np.random.default_rng()
-        syndromes = rng.binomial(1, p_flip, size=(num_samples, n_detectors)).astype(np.uint8)
-
-        # Logical error per cycle proxy: higher if we remove DQLR or increase CZ residuals, etc.
-        ler = min(0.5, 0.25 * self.cfg.p_cz_excess +
-                         0.25 * self.cfg.p_cz_leak_11_to_02 +
-                         0.25 * self.cfg.p_cz_crosstalk_ZZ +
-                         0.25 * self.cfg.p_cz_swap_like)
-        logicals = rng.binomial(1, ler, size=(num_samples, n_observables)).astype(np.uint8)
- 
-        # Build your existing Pauli+ circuit and then *instrument it* per paper
-        self.sim = PauliPlusSimulator(config, basis)
-        # The PauliPlusSimulator owns the Stim circuit; we attach paper-aligned noise.
-        self.sim.apply_paper_aligned_noise(config=self.cfg.__dict__)
-
-    def _load_cfg(self, config: Dict) -> PaperAlignedConfig:
-        """Convert a raw dict of parameters into a structured config object."""
-        fields = PaperAlignedConfig.__annotations__.keys()
-        values = {k: float(config.get(k, 0.0)) for k in fields}
-        return PaperAlignedConfig(**values)
-
-    def sample(self, num_samples: int) -> Tuple[np.ndarray, np.ndarray]:
-        """Sample via Stim using the detector layout in the underlying circuit."""
+    def sample(self, num_samples: int):
+        """Sample using the underlying simulator."""
         sampler = self.sim.circuit.compile_detector_sampler()
-        syndromes, logicals = sampler.sample(num_samples, separate_observables=True)
- 
- 
-        return syndromes, logicals
+        return sampler.sample(num_samples, separate_observables=True)


### PR DESCRIPTION
## Summary
- add passive heating and DQLR channels for paper-aligned noise
- approximate leakage transport between leaked states within qutrit model
- rebuild paper-aligned noise model to twirl heating and DQLR via GPT

## Testing
- `pytest google_qec_paper_noise_model/tests -q`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_b_68b53dcfac80832aaee78fc36eb22966