### PR TITLE
Implement exact two-qubit GPT and CZ noise modeling

### DIFF
--- a/google_qec_paper_noise_model/gpta.py
+++ b/google_qec_paper_noise_model/gpta.py
@@ -1,112 +1,142 @@
 from __future__ import annotations
 import numpy as np
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
-# Utilities for Pauli basis
-I = np.array([[1,0],[0,1]], dtype=complex)
-X = np.array([[0,1],[1,0]], dtype=complex)
-Y = np.array([[0,-1j],[1j,0]], dtype=complex)
-Z = np.array([[1,0],[0,-1]], dtype=complex)
+# --------
+# Pauli bases
+# --------
+I = np.array([[1, 0], [0, 1]], dtype=complex)
+X = np.array([[0, 1], [1, 0]], dtype=complex)
+Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+Z = np.array([[1, 0], [0, -1]], dtype=complex)
 PAULI_1Q = [I, X, Y, Z]
 
 def _kron(*ops: np.ndarray) -> np.ndarray:
-    out = np.array([[1.0+0j]])
+    out = np.array([[1.0 + 0j]])
     for op in ops:
         out = np.kron(out, op)
     return out
 
-def _project_to_qubit(K: np.ndarray) -> np.ndarray:
-    """Take top-left 2x2 block of a 3x3 (qutrit) Kraus op to act in qubit subspace."""
-    if K.shape[0] == 2:
-        return K
-    return K[:2,:2]
+PAULI_2Q: List[np.ndarray] = [_kron(a, b) for a in PAULI_1Q for b in PAULI_1Q]
+# order: {I,X,Y,Z} ⊗ {I,X,Y,Z}
 
-def _apply_kraus(Ks: List[np.ndarray], A: np.ndarray) -> np.ndarray:
-    return sum(K @ A @ K.conj().T for K in Ks)
+# --------
+# Helpers: project Kraus ops to qubit subspace
+# --------
+
+def _project_1q_to_qubit(K: np.ndarray) -> np.ndarray:
+    return K if K.shape[0] == 2 else K[:2, :2]
+
+def _project_2q_to_qubit(K: np.ndarray) -> np.ndarray:
+    if K.shape[0] == 4:
+        return K
+    comp = [0, 1, 3, 4]
+    K4 = np.zeros((4, 4), dtype=complex)
+    for a, ia in enumerate(comp):
+        for b, ib in enumerate(comp):
+            K4[a, b] = K[ia, ib]
+    return K4
+
+# --------
+# Leakage estimates
+# --------
+
+def _avg_leakage_1q(Ks: List[np.ndarray]) -> float:
+    rho1_3 = np.zeros((3, 3), complex); rho1_3[1, 1] = 1.0
+    Ks3: List[np.ndarray] = []
+    for K in Ks:
+        if K.shape[0] == 2:
+            K3 = np.zeros((3, 3), complex)
+            K3[:2, :2] = K
+            K3[2, 2] = 1.0
+            Ks3.append(K3)
+        else:
+            Ks3.append(K)
+    E = sum(K @ rho1_3 @ K.conj().T for K in Ks3)
+    return float(np.real(E[2, 2]))
+
+def _avg_leakage_2q(Ks: List[np.ndarray]) -> float:
+    if all(K.shape[0] == 4 for K in Ks):
+        return 0.0
+    comp = [0, 1, 3, 4]
+    leaked = 0.0
+    for basis_idx in comp:
+        rho = np.zeros((9, 9), complex); rho[basis_idx, basis_idx] = 1.0
+        E = sum(K @ rho @ K.conj().T for K in Ks)
+        mask = np.zeros(9, float)
+        for i in range(3):
+            for j in range(3):
+                if i == 2 or j == 2:
+                    mask[3 * i + j] = 1.0
+        leaked += float(np.real(np.sum(np.diag(E) * mask)))
+    return leaked / 4.0
+
+# --------
+# PTM diagonals and conversions to Pauli probs
+# --------
 
 def _ptm_diag_from_kraus_1q(Ks: List[np.ndarray]) -> np.ndarray:
-    """
-    Compute the diagonal of the 1-qubit Pauli transfer matrix T (size 4),
-    where T_{ij} = 1/2 Tr( P_i E(P_j) ), P_0=I. For Pauli-twirled channel
-    the off-diagonals vanish; we need diag entries [1, λx, λy, λz].
-    """
-    # Project to computational subspace if 3x3
-    Ks2 = [ _project_to_qubit(K) for K in Ks ]
+    Ks2 = [_project_1q_to_qubit(K) for K in Ks]
     lam = np.zeros(4, dtype=float)
     for idx, P in enumerate(PAULI_1Q):
-        EP = _apply_kraus(Ks2, P)
+        EP = sum(K @ P @ K.conj().T for K in Ks2)
         lam[idx] = 0.5 * np.real(np.trace(P.conj().T @ EP))
-    # enforce exact λ0 = 1 for CPTP in PTM
+    lam[0] = 1.0
+    return lam
+
+def _ptm_diag_from_kraus_2q(Ks: List[np.ndarray]) -> np.ndarray:
+    lam = np.zeros(16, dtype=float)
+    for idx, P in enumerate(PAULI_2Q):
+        EP = sum(K @ P @ K.conj().T for K in Ks)
+        lam[idx] = 0.25 * np.real(np.trace(P.conj().T @ EP))
     lam[0] = 1.0
     return lam
 
 def _hadamard4() -> np.ndarray:
-    """Walsh-Hadamard-like matrix for mapping eigenvalues -> Pauli probabilities."""
-    H = np.array([
-        [1,  1,  1,  1],
-        [1,  1, -1, -1],
-        [1, -1,  1, -1],
-        [1, -1, -1,  1],
-    ], dtype=float)
-    return H
+    return np.array([[1, 1, 1, 1],
+                     [1, 1, -1, -1],
+                     [1, -1, 1, -1],
+                     [1, -1, -1, 1]], dtype=float)
+
+def _hadamard16() -> np.ndarray:
+    H4 = _hadamard4()
+    return np.kron(H4, H4)
 
 def _lam_to_probs_1q(lam: np.ndarray) -> np.ndarray:
-    """
-    For a 1-qubit Pauli channel, probabilities over {I,X,Y,Z} relate to eigenvalues
-    {1, λx, λy, λz} via p = (1/4) H lam, with H given by _hadamard4().
-    """
     H = _hadamard4()
-    p = (H @ lam.reshape(4,1)).ravel() / 4.0
-    # numeric cleanup
+    p = (H @ lam.reshape(4, 1)).ravel() / 4.0
     p[p < 0] = 0.0
     s = p.sum()
-    if s <= 0:
-        p = np.array([1,0,0,0], dtype=float)
-    else:
-        p /= s
-    return p
+    return p / s if s > 0 else np.array([1, 0, 0, 0], float)
+
+def _lam_to_probs_2q(lam: np.ndarray) -> np.ndarray:
+    H = _hadamard16()
+    p = (H @ lam.reshape(16, 1)).ravel() / 16.0
+    p[p < 0] = 0.0
+    s = p.sum()
+    return p / s if s > 0 else np.eye(16, dtype=float)[0]
+
+# --------
+# Public API
+# --------
 
 def twirl_to_pauli_channel(Ks: List[np.ndarray], n_qubits: int) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Generalized Pauli Twirling Approximation:
-      - Accept Kraus ops (optionally in 3x3 space for leakage); we project to qubit subspace
-        before twirling, preserving any leakage probability as 'lost' population.
-      - Return (probs, leak), where
-         probs: ndarray of shape (4,) for 1q or (16,) for 2q (factorized from 1q eigens)
-         leak:  estimated leakage probability mass (population that left {|0>,|1>}).
-    For 2 qubits we approximate the twirl as a Kronecker of 1q twirls (sufficient for sampling
-    in Pauli+; exact two-qubit twirl can be added later if needed).
-    """
     if n_qubits == 1:
         lam = _ptm_diag_from_kraus_1q(Ks)
         probs = _lam_to_probs_1q(lam)
-        # crude leakage estimate: how much |1> populations do not stay in subspace on |1><1|
-        rho1 = np.array([[0,0],[0,1]], dtype=complex)
-        rho1_3 = np.zeros((3,3), complex); rho1_3[1,1] = 1.0
-        # Promote Ks to 3x3 if needed for leakage accounting
-        Ks3 = []
-        for K in Ks:
-            if K.shape[0] == 2:
-                K3 = np.zeros((3,3), complex)
-                K3[:2,:2] = K
-                K3[2,2] = 1.0
-                Ks3.append(K3)
-            else:
-                Ks3.append(K)
-        E_rho1 = sum(K @ rho1_3 @ K.conj().T for K in Ks3)
-        leak = float(np.real(E_rho1[2,2]))
+        leak = _avg_leakage_1q(Ks)
         return probs, leak
     elif n_qubits == 2:
-        # Factorized approximation: get 1q twirls for each side if channels are separable.
-        # If not separable, we still use identical marginal twirls on both qubits, which
-        # is sufficient to feed a Pauli+ sampler.
-        lam = _ptm_diag_from_kraus_1q(Ks)  # use same marginal as 1q
-        p1 = _lam_to_probs_1q(lam)
-        probs = np.kron(p1, p1)  # 16 entries in {I,X,Y,Z}⊗{I,X,Y,Z}
-        # leakage heuristic: same as 1q, twice
-        _, leak1 = twirl_to_pauli_channel(Ks, 1)
-        leak = 1.0 - (1.0 - leak1)**2
+        if Ks and Ks[0].shape[0] in (2, 3):
+            lam = _ptm_diag_from_kraus_1q(Ks)
+            p1 = _lam_to_probs_1q(lam)
+            probs = np.kron(p1, p1)
+            leak = 1.0 - (1.0 - _avg_leakage_1q(Ks)) ** 2
+            return probs, leak
+        Ks4 = [_project_2q_to_qubit(K) for K in Ks]
+        lam = _ptm_diag_from_kraus_2q(Ks4)
+        probs = _lam_to_probs_2q(lam)
+        leak = _avg_leakage_2q(Ks)
         return probs, leak
     else:
         raise NotImplementedError("Only 1 or 2 qubits supported")
-

--- a/simulator/pauli_plus_simulator.py
+++ b/simulator/pauli_plus_simulator.py
@@ -39,7 +39,9 @@ from google_qec_paper_noise_model.channels import (
     lift_qubit_to_qutrit,
     passive_heating_kraus,
     dqlr_kraus,
-    leakage_injection_kraus,
+    leakage_injection_kraus,     # kept for completeness
+    cz_induced_leakage_kraus,    # new: two‑qutrit CZ‑leakage model
+    leakage_transport_kraus,     # new: two‑qutrit leakage transport
 )
 from google_qec_paper_noise_model.kraus_utils import combine_kraus_channels
 
@@ -185,20 +187,30 @@ class PauliPlusSimulator:
             float(dqlr_probs[3]),
         )
 
-        # CZ leakage and transport channels approximated via single-qubit twirls.
-        cz_px = cz_py = cz_pz = 0.0
+        # ----- Exact two-qubit GPT for CZ-related channels (paper method) -----
+        # Build composed two‑qutrit channel for (leakage during CZ) ∘ (leakage transport)
+        cz_Ks: List = []
         if p_cz_leak > 0:
-            leak_probs, _ = twirl_to_pauli_channel(
-                leakage_injection_kraus(p_cz_leak / 2.0), 1
-            )
-            cz_px += float(leak_probs[1])
-            cz_py += float(leak_probs[2])
-            cz_pz += float(leak_probs[3])
+            cz_Ks = cz_induced_leakage_kraus(p_cz_leak)
         if p_leak_transport > 0:
-            s = p_leak_transport / 3.0
-            cz_px += s
-            cz_py += s
-            cz_pz += s
+            Ks_move = leakage_transport_kraus(p_leak_transport)
+            cz_Ks = Ks_move if not cz_Ks else combine_kraus_channels(cz_Ks, Ks_move)
+        # Twirl to exact 2‑qubit Pauli channel (16 probs including II)
+        cz_probs16 = None
+        if cz_Ks:
+            cz_probs16, _ = twirl_to_pauli_channel(cz_Ks, 2)
+        # Helper: map 16‑probs (II,IX,IY,IZ, XI,XX,XY,XZ, YI,YX,YY,YZ, ZI,ZX,ZY,ZZ)
+        # to Stim PAULI_CHANNEL_2 args (15 probs for everything except II).
+        def _probs16_to_stim_args(p16):
+            order = [1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15]  # exclude 0=II
+            return [float(p16[i]) for i in order]
+        # Uniform 2‑qubit depolarizing "excess" to be added on top if configured.
+        def _add_cz_excess(args15: List[float]) -> List[float]:
+            if p_cz_excess <= 0:
+                return args15
+            u = p_cz_excess / 15.0
+            scale = 1.0 - p_cz_excess
+            return [a * scale + u for a in args15]
 
         new_circuit = stim.Circuit()
         current_cz_pairs: List[Tuple[int, int]] = []
@@ -208,6 +220,15 @@ class PauliPlusSimulator:
             if px_ <= 0 and py_ <= 0 and pz_ <= 0:
                 return
             new_circuit.append_operation("PAULI_CHANNEL_1", [q], [px_, py_, pz_])
+
+        def add_pauli_ch2(a: int, b: int, probs16) -> None:
+            if probs16 is None:
+                return
+            args15 = _probs16_to_stim_args(probs16)
+            args15 = _add_cz_excess(args15)
+            if all(v <= 0 for v in args15):
+                return
+            new_circuit.append_operation("PAULI_CHANNEL_2", [a, b], args15)
 
         def inject_cz_pair(a: int, b: int) -> None:
             if p_cz_zz > 0:
@@ -227,13 +248,8 @@ class PauliPlusSimulator:
                     [stim.target_y(a), stim.target_y(b)],
                     0.5 * p_cz_swap,
                 )
-            if cz_px > 0 or cz_py > 0 or cz_pz > 0:
-                add_pauli_ch1(a, cz_px, cz_py, cz_pz)
-                add_pauli_ch1(b, cz_px, cz_py, cz_pz)
-            if p_cz_excess > 0:
-                s = p_cz_excess / 3.0
-                add_pauli_ch1(a, s, s, s)
-                add_pauli_ch1(b, s, s, s)
+            # Inject exact 2‑qubit Pauli channel from GPT of two‑qutrit CZ noise
+            add_pauli_ch2(a, b, cz_probs16)
 
         for inst in self.circuit:
             name = inst.name


### PR DESCRIPTION
## Summary
- Expand GPT utilities with two-qubit Pauli basis, leakage tracking, and PTM-based twirling
- Model CZ leakage and transport using full two-qutrit channels and convert to exact two-qubit Pauli channels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6bb93d21c832aaaedc761c3713fc9