### PR TITLE
Expose paper-aligned circuit builder

### DIFF
--- a/my_noise_model/__init__.py
+++ b/my_noise_model/__init__.py
@@ -12,6 +12,7 @@ from .iq_readout import IQReadoutModel
 from .softxor import soft_xor, soft_detection_sequence
 from .gpta import twirl_to_pauli_channel
 from .pauli_plus import build_pauli_plus_channels
+from .circuit_builder import build_paper_aligned_circuit
 
 __all__ = [
     "make_si1000_weights",
@@ -20,5 +21,6 @@ __all__ = [
     "soft_detection_sequence",
     "twirl_to_pauli_channel",
     "build_pauli_plus_channels",
+    "build_paper_aligned_circuit",
 ]
 

--- a/my_noise_model/circuit_builder.py
+++ b/my_noise_model/circuit_builder.py
@@ -8,7 +8,7 @@ Build a Stim circuit with a **paper-accurate** Pauli+ noise model:
 This mirrors Methods (Pauli+, cross-talk & leakage; soft I/Q with amplitude damping).
 """
 from pathlib import Path
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 import yaml
 import stim
 import numpy as np
@@ -215,6 +215,28 @@ class SurfaceCodeCircuitBuilder:
         # Flush any trailing tick’s cross-talk
         self._append_cross_talk_for_tick(noisy, current_tick_cz, p_xtalk)
         return noisy
+
+
+def build_paper_aligned_circuit(config: Dict[str, Any], basis: str) -> stim.Circuit:
+    """Builds a Stim circuit using :class:`SurfaceCodeCircuitBuilder`.
+
+    Parameters
+    ----------
+    config : Dict[str, Any]
+        Configuration dictionary that may contain ``distance``, ``rounds`` and
+        ``processor`` keys. Missing values fall back to small demonstrative
+        defaults.
+    basis : str
+        Logical basis (``'x'`` or ``'z'``) for the generated surface code
+        circuit.
+    """
+    distance = int(config.get("distance", 3))
+    rounds = int(config.get("rounds", 3))
+    processor = config.get("processor", "72_qubit_paper_aligned")
+    builder = SurfaceCodeCircuitBuilder(
+        distance=distance, rounds=rounds, basis=basis, processor=processor
+    )
+    return builder.build_circuit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add build_paper_aligned_circuit helper wrapping SurfaceCodeCircuitBuilder
- export paper-aligned circuit builder from my_noise_model package

## Testing
- `pytest -q`
- `python generate_data.py --model paper_aligned --samples 1 --basis z`


------
https://chatgpt.com/codex/tasks/task_b_68bc37514e68832a9555ec2afad91055