### PR TITLE
Improve npy viewer error handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,12 @@ python google_qec_simulator/main.py path/to/exp --shots 10000 --device npu
 
 ### 2. 查看数据
 
+生成的数据文件名会包含时间戳，例如 `output/dem_syndromes_z_20240229_101530.npy`。查看时可以先列出
+`output/` 目录下的 `.npy` 文件，再将其中一个路径传给 `npy_viewer.py`：
+
 ```bash
-python npy_viewer.py output/dem_samples.npy
+ls output/*.npy
+python npy_viewer.py output/dem_syndromes_z_20240229_101530.npy
 ```
 
 ### 3. 训练模型
@@ -106,7 +110,7 @@ python ai_models/train.py --config configs/dem.yaml
 ```bash
 python ai_models/decode.py \
   --model path/to/alphaqubit_model.pth \
-  --data output/dem_samples.npy
+  --data output/dem_syndromes_z_20240229_101530.npy
 ```
 
 解码结果（如逻辑错误率）将存于 `results/` 目录。

--- a/npy_viewer.py
+++ b/npy_viewer.py
@@ -1,6 +1,8 @@
 # stats.py
-import numpy as np
 import sys
+from pathlib import Path
+
+import numpy as np
 
 def main():
     if len(sys.argv) < 2:
@@ -8,11 +10,24 @@ def main():
         return
 
     file_path = sys.argv[1]
-    data = np.load(file_path)
+    path = Path(file_path)
+
+    if not path.exists():
+        print(f"Error: {file_path} does not exist.")
+        parent = path.parent if path.parent != Path("") else Path.cwd() / "output"
+        if parent.exists():
+            npy_files = sorted(parent.glob("*.npy"))
+            if npy_files:
+                print("\nAvailable .npy files:")
+                for candidate in npy_files:
+                    print(f"  - {candidate}")
+        return
+
+    data = np.load(path)
     
     # Basic stats
     print(f"\n{' File Info ':-^40}")
-    print(f"Path: {file_path}")
+    print(f"Path: {path}")
     print(f"Shape: {data.shape}")
     print(f"Dtype: {data.dtype}")
     print(f"Min/Mean/Max: {data.min()} / {data.mean():.2f} / {data.max()}")


### PR DESCRIPTION
## Summary
- update `npy_viewer.py` to provide a clearer message when the requested `.npy` file is missing and list available files
- document the timestamped `.npy` outputs in the README and refresh viewer/decoder usage examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68d4ee02c250832ab56d676fa7e4aa31