### PR TITLE
Silence invalid escape warnings in noise model docstrings

### DIFF
--- a/my_noise_model/channels.py
+++ b/my_noise_model/channels.py
@@ -29,7 +29,7 @@ def kron(*ops: np.ndarray) -> np.ndarray:
     return out
 
 def amplitude_damping_kraus(tau: float) -> List[np.ndarray]:
-    """单量子比特振幅阻尼通道。
+    r"""单量子比特振幅阻尼通道。
 
     ``tau`` 表示归一化的演化时间，阻尼强度 ``γ = 1 - e^{-tau}``。
     返回两个 Kraus 算符 ``K0`` 与 ``K1``，分别对应保持在计算子空间和
@@ -72,7 +72,7 @@ def depolarizing_2q_kraus(p: float) -> List[np.ndarray]:
     return K
 
 def leakage_injection_kraus(p: float) -> List[np.ndarray]:
-    """单 qutrit 泄漏注入通道。
+    r"""单 qutrit 泄漏注入通道。
 
     以概率 ``p`` 将 ``\|0⟩, \|1⟩, \|2⟩`` 全部泵浦到泄漏态 ``\|2⟩``，否则保持不变。
     Kraus 集满足 CPTP 条件：
@@ -98,7 +98,7 @@ def lift_qubit_to_qutrit(Ks_2x2: List[np.ndarray]) -> List[np.ndarray]:
     return out
 
 def cz_induced_leakage_kraus(p_leak: float) -> List[np.ndarray]:
-    """双四能级系统（两量子比特 + 泄漏态）的 CZ 诱导泄漏通道。
+    r"""双四能级系统（两量子比特 + 泄漏态）的 CZ 诱导泄漏通道。
 
     模拟 ``\|11⟩`` 态在 CZ 作用下转移到 ``\|02⟩`` 与 ``\|20⟩`` 的过程，每个分支
     概率 ``p_leak/2``。其余基态（包含泄漏运输需要的第四能级）保持不变。
@@ -121,7 +121,7 @@ def cz_induced_leakage_kraus(p_leak: float) -> List[np.ndarray]:
     return [K0, K1, K2]
 
 def leakage_transport_kraus(p_move: float) -> List[np.ndarray]:
-    """四能级泄漏迁移通道。
+    r"""四能级泄漏迁移通道。
 
     论文中描述了 ``\|12⟩``/``\|21⟩`` 泄漏态在泄漏管理脉冲作用下向另一量子比特
     迁移的过程：
@@ -154,7 +154,7 @@ def leakage_transport_kraus(p_move: float) -> List[np.ndarray]:
 
 
 def dqlr_kraus(p_matrix: List[List[float]]) -> List[np.ndarray]:
-    """生成 DQLR 复位过程的 Kraus 算符。
+    r"""生成 DQLR 复位过程的 Kraus 算符。
 
     ``p_matrix`` 为 3×3 转移矩阵，列索引 ``j`` 表示复位前的能级 ``\|j⟩``，行
     索引 ``i`` 表示复位后的目标能级 ``\|i⟩``。只要每一列概率和为 1，即可保
@@ -177,7 +177,7 @@ def spectator_crosstalk_z_kraus(p: float) -> List[np.ndarray]:
     return dephasing_kraus(p)
 
 def multi_level_reset_kraus(f_reset: float, rel_leak_after: float) -> List[np.ndarray]:
-    """三能级复位过程：以保真度 ``f_reset`` 复位到 ``\|0⟩``，并保留 ``rel_leak_after`` 泄漏。"""
+    r"""三能级复位过程：以保真度 ``f_reset`` 复位到 ``\|0⟩``，并保留 ``rel_leak_after`` 泄漏。"""
     f = float(f_reset)
     r = float(rel_leak_after)
     # Kraus mapping everything to |0> with prob f, and to |2> with small r,

--- a/my_noise_model/circuit_builder.py
+++ b/my_noise_model/circuit_builder.py
@@ -69,7 +69,7 @@ def _twirl_pauli_probs_2q_with_leakage(
     t2: float,
     p_cz_leak: float,
 ) -> Tuple[np.ndarray, float]:
-    """针对双量子比特通道执行广义 Pauli 托恩并返回泄漏概率。
+    r"""针对双量子比特通道执行广义 Pauli 托恩并返回泄漏概率。
 
     组合了以下物理机制：
 

--- a/my_noise_model/gpta.py
+++ b/my_noise_model/gpta.py
@@ -1,4 +1,4 @@
-"""gpta.py —— 广义 Pauli 托恩近似 (GPTA) 的矩阵实现细节。
+r"""gpta.py —— 广义 Pauli 托恩近似 (GPTA) 的矩阵实现细节。
 
 与 ``gpt.py`` 中的高层接口互补，这里提供对 Kraus 集投影、计算 Pauli 传输矩阵
 对角元、估计泄漏概率等底层线性代数操作。每个步骤都附有中文注释以说明其
@@ -53,7 +53,7 @@ def _project_2q_to_qubit(K: np.ndarray) -> np.ndarray:
 # --------
 
 def _avg_leakage_1q(Ks: List[np.ndarray]) -> float:
-    """估计单量子比特通道将 ``\|1⟩`` 泄漏至 ``\|2⟩`` 的平均概率。"""
+    r"""估计单量子比特通道将 ``\|1⟩`` 泄漏至 ``\|2⟩`` 的平均概率。"""
     rho1_3 = np.zeros((3, 3), complex); rho1_3[1, 1] = 1.0
     Ks3: List[np.ndarray] = []
     for K in Ks:

--- a/my_noise_model/iq_readout.py
+++ b/my_noise_model/iq_readout.py
@@ -1,4 +1,4 @@
-"""iq_readout.py —— 软测量 (I/Q) 似然与后验模型。
+r"""iq_readout.py —— 软测量 (I/Q) 似然与后验模型。
 
 根据论文方法，测量结果被视为一维高斯分布的 I/Q 样本：\|0⟩ 与 \|1⟩ 的均值由
 信噪比 (SNR) 决定，泄漏态使用宽而居中的分布。该文件提供后验概率计算、
@@ -26,7 +26,7 @@ class IQReadoutModel:
     leak_sigma_scale: float = 1.6
 
     def _means(self) -> Tuple[float, float]:
-        """根据 SNR 与阻尼时间常数计算 \|0⟩/\|1⟩ 高斯分布的均值。"""
+        r"""根据 SNR 与阻尼时间常数计算 \|0⟩/\|1⟩ 高斯分布的均值。"""
         mu = 0.5 * self.snr
         # amplitude damping collapses the |1> cloud toward |0|
         # We use alpha = exp(-tau) as the retained |1| amplitude component.

--- a/my_noise_model/kraus_utils.py
+++ b/my_noise_model/kraus_utils.py
@@ -171,7 +171,7 @@ def combine_kraus_channels(
 
 
 def kraus_leakage_heating(p01: float, p12: float) -> list[np.ndarray]:
-    """三能级被动加热通道：依次执行 ``\|0⟩→\|1⟩`` 与 ``\|1⟩→\|2⟩``。"""
+    r"""三能级被动加热通道：依次执行 ``\|0⟩→\|1⟩`` 与 ``\|1⟩→\|2⟩``。"""
 
     p01 = float(p01)
     p12 = float(p12)
@@ -191,13 +191,13 @@ def kraus_leakage_heating(p01: float, p12: float) -> list[np.ndarray]:
 
 
 def kraus_heating_to_2(prob: float) -> list[np.ndarray]:
-    """兼容旧模型的便捷函数，仅保留 ``\|1⟩→\|2⟩`` 加热。"""
+    r"""兼容旧模型的便捷函数，仅保留 ``\|1⟩→\|2⟩`` 加热。"""
 
     return kraus_leakage_heating(0.0, prob)
 
 
 def kraus_cz_leakage(prob: float) -> list[np.ndarray]:
-    """CZ 门导致的 ``\|11⟩``→``\|02⟩/\|20⟩`` 泄漏通道。"""
+    r"""CZ 门导致的 ``\|11⟩``→``\|02⟩/\|20⟩`` 泄漏通道。"""
 
     p = float(prob)
     dim = 9


### PR DESCRIPTION
## Summary
- mark docstrings using Dirac bra-ket notation as raw strings to avoid invalid escape warnings during import
- ensure noise model modules no longer emit SyntaxWarning messages without changing runtime behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d631797194832aaeb15dbf5bf0e247