### PR TITLE
Handle short softxor measurement sequences

### DIFF
--- a/my_noise_model/softxor.py
+++ b/my_noise_model/softxor.py
@@ -11,11 +11,19 @@ def soft_xor(p: np.ndarray, q: np.ndarray) -> np.ndarray:
 def soft_detection_sequence(meas_probs: Iterable[np.ndarray]) -> Tuple[np.ndarray, np.ndarray]:
     """根据每轮测量的软概率生成检测事件与泄漏轨迹。"""
     probs = [np.asarray(x, dtype=float) for x in meas_probs]
+
+    if not probs:
+        empty = np.zeros((0,), dtype=float)
+        return empty, empty
+
     p1s = [p[..., 1] for p in probs]
-    det_outs = []
-    for t in range(1, len(p1s)):
-        det_outs.append(soft_xor(p1s[t - 1], p1s[t]))
-    det = np.stack(det_outs, axis=0)
+    det_outs = [soft_xor(p1s[t - 1], p1s[t]) for t in range(1, len(p1s))]
+
+    if det_outs:
+        det = np.stack(det_outs, axis=0)
+    else:
+        det = np.zeros((0, *p1s[0].shape), dtype=float)
+
     leak = np.stack([p[..., 2] for p in probs], axis=0)
     return det, leak
 

--- a/tests/test_iq_softxor.py
+++ b/tests/test_iq_softxor.py
@@ -22,6 +22,16 @@ def test_soft_detection_sequence_shape():
     assert leak.shape == (3, 2)
     assert np.allclose(leak, [[0.05, 0.1], [0.05, 0.1], [0.05, 0.1]])
 
+
+def test_soft_detection_sequence_single_round():
+    seq = [np.array([[0.9, 0.05, 0.05], [0.8, 0.1, 0.1]])]
+    det, leak = soft_detection_sequence(seq)
+    assert det.shape == (0, 2)
+    assert leak.shape == (1, 2)
+    assert np.all(det == 0.0)
+    assert np.allclose(leak, [[0.05, 0.1]])
+
+
 def test_iq_posteriors_sum_to_one():
     model = IQReadoutModel(snr=10.0, tau=0.01, p_leak_prior=1e-3)
     rng = np.random.default_rng(1)


### PR DESCRIPTION
## Summary
- guard the softxor detection helper against empty inputs and reuse soft xor logic for single-step transitions
- materialize zero-length detection tensors when only one round of measurements is provided
- add regression coverage for the single-round measurement case

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d74ad60488832ab6ba43cccf81743b