### PR TITLE
Support directory targets in run_decode_all

### DIFF
--- a/run_decode_all.py
+++ b/run_decode_all.py
@@ -132,16 +132,32 @@ def parse_args() -> argparse.Namespace:
 def resolve_targets(args: argparse.Namespace) -> List[Path]:
     if args.targets:
         paths: Set[Path] = set()
+        patterns: Sequence[str] = tuple(args.pattern) if args.pattern else DEFAULT_PATTERNS
+
         for spec in args.targets:
-            expanded = list(Path().glob(spec))
+            try:
+                expanded = list(Path().glob(spec))
+            except NotImplementedError:
+                expanded = []
             if not expanded:
                 # Treat as literal path (may include relative components)
                 candidate = Path(spec)
                 if candidate.exists():
                     expanded = [candidate]
+
             for path in expanded:
                 if path.is_file() and path.suffix.lower() in {".npy", ".npz"}:
                     paths.add(path.resolve())
+                elif path.is_dir():
+                    for pattern in patterns:
+                        iterator: Iterable[Path]
+                        if args.recursive:
+                            iterator = path.rglob(pattern)
+                        else:
+                            iterator = path.glob(pattern)
+                        for candidate in iterator:
+                            if candidate.is_file():
+                                paths.add(candidate.resolve())
         return sorted(paths)
 
     root: Path = args.data_root

--- a/tests/test_run_decode_all.py
+++ b/tests/test_run_decode_all.py
@@ -1,0 +1,52 @@
+from argparse import Namespace
+from importlib import util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "run_decode_all.py"
+SPEC = util.spec_from_file_location("run_decode_all", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+_MODULE = util.module_from_spec(SPEC)
+SPEC.loader.exec_module(_MODULE)
+
+resolve_targets = _MODULE.resolve_targets
+
+
+def make_args(**overrides):
+    defaults = dict(
+        targets=[],
+        pattern=None,
+        recursive=False,
+        data_root=Path("output"),
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_directory_target_collects_np_files(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    npy_file = data_dir / "sample.npy"
+    npy_file.write_bytes(b"binary")
+
+    args = make_args(targets=[str(data_dir)])
+
+    result = resolve_targets(args)
+
+    assert result == [npy_file.resolve()]
+
+
+def test_directory_target_respects_recursive_flag(tmp_path):
+    parent = tmp_path / "parent"
+    nested = parent / "nested"
+    nested.mkdir(parents=True)
+    file_in_nested = nested / "deep.npz"
+    file_in_nested.write_bytes(b"content")
+
+    # Without recursion the nested file should not be picked up.
+    args_non_recursive = make_args(targets=[str(parent)], recursive=False)
+    assert resolve_targets(args_non_recursive) == []
+
+    # With recursion we collect the nested file.
+    args_recursive = make_args(targets=[str(parent)], recursive=True)
+    assert resolve_targets(args_recursive) == [file_in_nested.resolve()]


### PR DESCRIPTION
## Summary
- allow `run_decode_all.py` to walk directory targets passed as positional arguments, including recursive traversal
- add unit tests covering directory and recursive target resolution behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68da844ab2e4832a871976c947fd3ef9